### PR TITLE
Add LeaderBoard command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.aliyun.tair</groupId>
     <artifactId>alibabacloud-tairjedis-sdk</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>alibabacloud-tairjedis-sdk</name>

--- a/src/main/java/com/aliyun/tair/ModuleCommand.java
+++ b/src/main/java/com/aliyun/tair/ModuleCommand.java
@@ -216,7 +216,29 @@ public enum ModuleCommand implements ProtocolCommand {
     STDDEVARRAYGET("STDDEV.ARRAY.GET"),
     STDDEVARRAYGETRANGE("STDDEV.ARRAY.GET.RANGE"),
     STDDEVARRAYGETTIMEMERGE("STDDEV.ARRAY.GET.TIME.MERGE"),
-    STDDEVARRAYGETRANGEMERGE("STDDEV.ARRAY.GET.RANGE.MERGE");
+    STDDEVARRAYGETRANGEMERGE("STDDEV.ARRAY.GET.RANGE.MERGE"),
+
+    // TairZset
+    EXZADD("exzadd"),
+    EXZINCRBY("exzincrby"),
+    EXZREM("exzrem"),
+    EXZREMRANGEBYSCORE("exzremrangebyscore"),
+    EXZREMRANGEBYRANK("exzremrangebyrank"),
+    EXZREMRANGEBYLEX("exzremrangebylex"),
+    EXZSCORE("exzscore"),
+    EXZRANGE("exzrange"),
+    EXZREVRANGE("exzrevrange"),
+    EXZRANGEBYSCORE("exzrangebyscore"),
+    EXZREVRANGEBYSCORE("exzrevrangebyscore"),
+    EXZRANGEBYLEX("exzrangebylex"),
+    EXZREVRANGEBYLEX("exzrevrangebylex"),
+    EXZCARD("exzcard"),
+    EXZRANK("exzrank"),
+    EXZREVRANK("exzrevrank"),
+    EXZRANKBYSCORE("exzrankbyscore"),
+    EXZREVRANKBYSCORE("exzrevrankbyscore"),
+    EXZCOUNT("exzcount"),
+    EXZLEXCOUNT("exzlexcount");
 
     private final byte[] raw;
 

--- a/src/main/java/com/aliyun/tair/leaderboard/DistributedLeaderBoard.java
+++ b/src/main/java/com/aliyun/tair/leaderboard/DistributedLeaderBoard.java
@@ -1,0 +1,469 @@
+package com.aliyun.tair.leaderboard;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.aliyun.tair.ModuleCommand;
+import com.aliyun.tair.leaderboard.params.RankParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.BuilderFactory;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.Protocol.Command;
+import redis.clients.jedis.util.JedisClusterCRC16;
+import redis.clients.jedis.util.SafeEncoder;
+
+import static com.aliyun.tair.leaderboard.LeaderBoard.joinScoresToString;
+import static redis.clients.jedis.Protocol.toByteArray;
+
+public class DistributedLeaderBoard {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DistributedLeaderBoard.class);
+
+    private static final String CH = "CH";
+    private static final String WITHSCORES = "WITHSCORES";
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final int DEFAULT_SHARDKEY_SIZE = 10;
+    private static final boolean DEFAULT_REVERSE = false;
+    private static final boolean DEFAULT_USE_ZERO_INDEX = true;
+
+    private final String name;
+    private final byte[] nameBinary;
+    private final JedisPool jedisPool;
+    private final int shardKeySize;
+    private final int pageSize;
+    private final boolean reverse;
+    private final boolean useZeroIndexForRank;
+
+    public DistributedLeaderBoard(String name, JedisPool jedisPool) {
+        this(name, jedisPool, DEFAULT_SHARDKEY_SIZE);
+    }
+
+    public DistributedLeaderBoard(String name, JedisPool jedisPool, int shardKeySize) {
+        this(name, jedisPool, shardKeySize, DEFAULT_PAGE_SIZE);
+    }
+
+    public DistributedLeaderBoard(String name, JedisPool jedisPool, int shardKeySize, int pageSize) {
+        this(name, jedisPool, shardKeySize, pageSize, DEFAULT_REVERSE);
+    }
+
+    public DistributedLeaderBoard(String name, JedisPool jedisPool, int shardKeySize, int pageSize, boolean reverse) {
+        this(name, jedisPool, shardKeySize, pageSize, reverse, DEFAULT_USE_ZERO_INDEX);
+    }
+
+    public DistributedLeaderBoard(String name, JedisPool jedisPool, int shardKeySize, int pageSize, boolean reverse,
+        boolean useZeroIndexForRank) {
+        this.name = name;
+        this.nameBinary = SafeEncoder.encode(name);
+        this.jedisPool = jedisPool;
+        this.shardKeySize = shardKeySize;
+        this.pageSize = pageSize;
+        this.reverse = reverse;
+        this.useZeroIndexForRank = useZeroIndexForRank;
+    }
+
+    private String crcKeyByMember(final String member) {
+        int index = JedisClusterCRC16.getSlot(member) % shardKeySize;
+        return name + "_" + index;
+    }
+
+    private String crcKeyByMember(final byte[] member) {
+        int index = JedisClusterCRC16.getSlot(member) % shardKeySize;
+        return name + "_" + index;
+    }
+
+    private String joinKeyAndIndex(final int index) {
+        return name + "_" + index;
+    }
+
+    /**
+     * Add a member to leaderboard.
+     *
+     * @param member the member
+     * @param scores the score
+     * @return true: success set or update, false: element already exists and has the same score.
+     */
+    public Boolean addMember(final String member, final String scores) {
+        return addMember(SafeEncoder.encode(member), SafeEncoder.encode(scores));
+    }
+
+    public Boolean addMember(final String member, final double... scores) {
+        return addMember(SafeEncoder.encode(member), SafeEncoder.encode(joinScoresToString(scores)));
+    }
+
+    public Boolean addMember(final byte[] member, final double... scores) {
+        return addMember(member, SafeEncoder.encode(joinScoresToString(scores)));
+    }
+
+    public Boolean addMember(final byte[] member, final byte[] score) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(ModuleCommand.EXZADD, SafeEncoder.encode(crcKeyByMember(member)),
+                SafeEncoder.encode(CH), score, member);
+            return BuilderFactory.BOOLEAN.build(obj);
+        }
+    }
+
+    /**
+     * Add multi members to leaderboard.
+     * @param memberScores key : member, value: score
+     * @return list of insert status.
+     */
+    public List<Boolean> addMember(final Map<String, String> memberScores) {
+        List<Boolean> results = new ArrayList<>();
+        try (Jedis jedis = jedisPool.getResource()) {
+            Pipeline p = jedis.pipelined();
+            for (Map.Entry<String, String> entry : memberScores.entrySet()) {
+                p.sendCommand(ModuleCommand.EXZADD, SafeEncoder.encode(crcKeyByMember(entry.getKey())),
+                    SafeEncoder.encode(CH), SafeEncoder.encode(entry.getValue()), SafeEncoder.encode(entry.getKey()));
+            }
+
+            List<Object> objs = p.syncAndReturnAll();
+            for (Object obj : objs) {
+                results.add(BuilderFactory.BOOLEAN.build(obj));
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Change score for member.
+     *
+     * @param member the member
+     * @param increment the increment (negative value to decrement)
+     * @return the new score of member.
+     */
+    public String incrScoreFor(final String member, final String increment) {
+        return incrScoreFor(SafeEncoder.encode(member), SafeEncoder.encode(increment));
+    }
+
+    public String incrScoreFor(final byte[] member, final byte[] increment) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(ModuleCommand.EXZINCRBY, SafeEncoder.encode(crcKeyByMember(member)),
+                increment, member);
+            return BuilderFactory.STRING.build(obj);
+        }
+    }
+
+    /**
+     * Remove member from leaderboard.
+     *
+     * @param member the member
+     * @return The number of members removed from the leaderboard.
+     */
+    public Long removeMember(final String member) {
+        return removeMember(SafeEncoder.encode(member));
+    }
+
+    public Long removeMember(final byte[] member) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(ModuleCommand.EXZREM, SafeEncoder.encode(crcKeyByMember(member)), member);
+            return BuilderFactory.LONG.build(obj);
+        }
+    }
+
+    /**
+     * Total members of the leaderboard.
+     *
+     * @return total members of the leaderboard, 0 if key does not exist.
+     */
+    public Long totalMembers() {
+        long rank = 0;
+        try (Jedis jedis = jedisPool.getResource()) {
+            Pipeline p = jedis.pipelined();
+            for (int i = 0; i < shardKeySize; i++) {
+                p.sendCommand(ModuleCommand.EXZCARD, SafeEncoder.encode(joinKeyAndIndex(i)));
+            }
+
+            List<Object> objs = p.syncAndReturnAll();
+            for (int i = 0; i < objs.size(); i++) {
+                if (objs.get(i) == null) {
+                    LOGGER.error("Could not find key: {}", SafeEncoder.encode(joinKeyAndIndex(i)));
+                    continue;
+                }
+                rank += BuilderFactory.LONG.build(objs.get(i));
+            }
+        }
+        return rank;
+    }
+
+    /**
+     * Total pages of the leaderboard.
+     *
+     * @return total pages of the leaderboard.
+     */
+    public Long totalPages() {
+        return (long)Math.ceil((double)totalMembers() / (double)pageSize);
+    }
+
+    /**
+     * The total of members in the current leaderboard in a score range.
+     *
+     * @param minScore Minimum score
+     * @param maxScore Maximum score
+     * @return Total of members in the current leaderboard in a score range.
+     */
+    public Long totalMembersInScoreRange(final double minScore, final double maxScore) {
+        String minScoreStr = joinScoresToString(minScore);
+        String maxScoreStr = joinScoresToString(maxScore);
+        return totalMembersInScoreRange(minScoreStr, maxScoreStr);
+    }
+
+    public Long totalMembersInScoreRange(final String minScore, final String maxScore) {
+        long counts = 0;
+        try (Jedis jedis = jedisPool.getResource()) {
+            Pipeline p = jedis.pipelined();
+            for (int i = 0; i < shardKeySize; i++) {
+                p.sendCommand(ModuleCommand.EXZCOUNT, SafeEncoder.encode(joinKeyAndIndex(i)),
+                    SafeEncoder.encode(minScore), SafeEncoder.encode(maxScore));
+            }
+
+            List<Object> objs = p.syncAndReturnAll();
+            for (int i = 0; i < objs.size(); i++) {
+                counts += BuilderFactory.LONG.build(objs.get(i));
+            }
+        }
+        return counts;
+    }
+
+    /**
+     * Remove members from the current leaderboard in a given score range.
+     *
+     * @param minScore Minimum score
+     * @param maxScore Maximum score
+     * @return the number of members removed.
+     */
+    public Long removeMembersInScoreRange(final double minScore, final double maxScore) {
+        String minScoreStr = joinScoresToString(minScore);
+        String maxScoreStr = joinScoresToString(maxScore);
+        return removeMembersInScoreRange(minScoreStr, maxScoreStr);
+    }
+
+    public Long removeMembersInScoreRange(final String minScore, final String maxScore) {
+        long counts = 0;
+        try (Jedis jedis = jedisPool.getResource()) {
+            Pipeline p = jedis.pipelined();
+            for (int i = 0; i < shardKeySize; i++) {
+                p.sendCommand(ModuleCommand.EXZREMRANGEBYSCORE, SafeEncoder.encode(joinKeyAndIndex(i)),
+                    SafeEncoder.encode(minScore), SafeEncoder.encode(maxScore));
+            }
+
+            List<Object> objs = p.syncAndReturnAll();
+            for (int i = 0; i < objs.size(); i++) {
+                counts += BuilderFactory.LONG.build(objs.get(i));
+            }
+        }
+        return counts;
+    }
+
+    /**
+     * Retrieve the score for a member in the current leaderboard.
+     *
+     * @param member Member
+     * @return Member score.
+     */
+    public String scoreFor(final String member) {
+        return scoreFor(SafeEncoder.encode(member));
+    }
+
+    public String scoreFor(final byte[] member) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(ModuleCommand.EXZSCORE, SafeEncoder.encode(crcKeyByMember(member)), member);
+            return BuilderFactory.STRING.build(obj);
+        }
+    }
+
+    /**
+     * Retrieve the rank for a member in the current leaderboard.
+     *
+     * @param member Member
+     * @return Rank for member in the current leaderboard.
+     */
+    public Long rankFor(final String member) {
+        return rankFor(SafeEncoder.encode(member), new RankParams());
+    }
+
+    public Long rankFor(final byte[] member) {
+        return rankFor(member, new RankParams());
+    }
+
+    public Long rankFor(final String member, final RankParams rankParams) {
+        return rankFor(SafeEncoder.encode(member), rankParams);
+    }
+
+    public Long rankFor(final byte[] member, final RankParams rankParams) {
+        long rank = 0;
+        String score = scoreFor(member);
+        if (score == null) {
+            return -1L;
+        }
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            Pipeline p = jedis.pipelined();
+            for (int i = 0; i < shardKeySize; i++) {
+                if (reverse) {
+                    p.sendCommand(ModuleCommand.EXZREVRANKBYSCORE,
+                        rankParams.getByteParams(SafeEncoder.encode(joinKeyAndIndex(i)), SafeEncoder.encode(score)));
+                } else {
+                    p.sendCommand(ModuleCommand.EXZRANKBYSCORE,
+                        rankParams.getByteParams(SafeEncoder.encode(joinKeyAndIndex(i)), SafeEncoder.encode(score)));
+                }
+            }
+
+            List<Object> objs = p.syncAndReturnAll();
+            for (int i = 0; i < objs.size(); i++) {
+                if (objs.get(i) == null) {
+                    LOGGER.error("Could not find key: {}", SafeEncoder.encode(joinKeyAndIndex(i)));
+                    continue;
+                }
+                rank += BuilderFactory.LONG.build(objs.get(i));
+            }
+        }
+
+        if (!useZeroIndexForRank) {
+            rank += 1;
+        }
+        if (reverse) {
+            rank -= 1;
+        }
+        return rank;
+    }
+
+    /**
+     * Retrieve score and rank for a member in the current leaderboard.
+     *
+     * @param member Member
+     * @return Score and rank for a member in the current leaderboard.
+     */
+    public LeaderData scoreAndRankFor(final String member) {
+        return scoreAndRankFor(SafeEncoder.encode(member));
+    }
+
+    public LeaderData scoreAndRankFor(final byte[] member) {
+        String score = scoreFor(member);
+        Long rank = rankFor(member);
+        return new LeaderData(new String(member), score, rank);
+    }
+
+    /**
+     * Get the leaderboard top number.
+     *
+     * @param number the number
+     * @return members from the leaderboard that fall within the given rank range.
+     */
+    public List<LeaderData> top(long number) {
+        List<LeaderData> leaderDataList = new ArrayList<>();
+
+        if (number < 1) {
+            number = 1;
+        }
+        long totalMembers = totalMembers();
+        long startRank = 0;
+        long endRank = number > totalMembers ? totalMembers-1 : number-1;
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            Pipeline p = jedis.pipelined();
+            for (int i = 0; i < shardKeySize; i++) {
+                if (reverse) {
+                    p.sendCommand(ModuleCommand.EXZREVRANGE, SafeEncoder.encode(joinKeyAndIndex(i)),
+                        toByteArray(startRank), toByteArray(endRank), SafeEncoder.encode(WITHSCORES));
+                } else {
+                    p.sendCommand(ModuleCommand.EXZRANGE, SafeEncoder.encode(joinKeyAndIndex(i)),
+                        toByteArray(startRank), toByteArray(endRank), SafeEncoder.encode(WITHSCORES));
+                }
+            }
+
+            List<Object> objs = p.syncAndReturnAll();
+            for (int i = 0; i < objs.size(); i++) {
+                if (objs.get(i) == null) {
+                    LOGGER.error("Could not find key: {}", SafeEncoder.encode(joinKeyAndIndex(i)));
+                    continue;
+                }
+
+                List<String> rangeRets = BuilderFactory.STRING_LIST.build(objs.get(i));
+                if (rangeRets != null) {
+                    for (int j = 0; j < rangeRets.size(); j += 2) {
+                        String member = rangeRets.get(j);
+                        String score = rangeRets.get(j + 1);
+                        Long rank = rankFor(member);
+                        leaderDataList.add(new LeaderData(member, score, rank));
+                    }
+                }
+            }
+        }
+        // sort and return sublist
+        if (reverse) {
+            leaderDataList.sort(Collections.reverseOrder());
+        } else {
+            Collections.sort(leaderDataList);
+        }
+        return leaderDataList.subList(0, (int)number);
+    }
+
+    /**
+     * Retrieve a page of leaders from the leaderboard.
+     *
+     * @param page the page
+     * @return a page of leaders from the leaderboard.
+     */
+    public List<LeaderData> leaders(long page) {
+        if (page < 1) {
+            page = 1;
+        }
+
+        long totalPage = totalPages();
+        if (page > totalPage) {
+            page = totalPage;
+        }
+
+        long startOffset = (page - 1) * pageSize;
+        long endOffset = startOffset + pageSize;
+
+        List<LeaderData> leaderDataList = top(endOffset);
+        return leaderDataList.subList((int)startOffset, (int)endOffset);
+    }
+
+    /**
+     * Expire the current leaderboard in a set number of seconds.
+     *
+     * @param seconds the seconds
+     * @return Number of seconds after which the leaderboard will be expired.
+     */
+    public Long expireLeaderBoard(final long seconds) {
+        long expires = 0;
+        try (Jedis jedis = jedisPool.getResource()) {
+            Pipeline p = jedis.pipelined();
+            for (int i = 0; i < shardKeySize; i++) {
+                p.sendCommand(Command.EXPIRE, SafeEncoder.encode(joinKeyAndIndex(i)), toByteArray(seconds));
+            }
+
+            List<Object> objs = p.syncAndReturnAll();
+            for (int i = 0; i < objs.size(); i++) {
+                expires += BuilderFactory.LONG.build(objs.get(i));
+            }
+        }
+        return expires;
+    }
+
+    /**
+     * Delete the current leaderboard.
+     * @return success: 1, not found: 0
+     */
+    public Long delLeaderBoard() {
+        long dels = 0;
+        try (Jedis jedis = jedisPool.getResource()) {
+            Pipeline p = jedis.pipelined();
+            for (int i = 0; i < shardKeySize; i++) {
+                p.sendCommand(Command.DEL, SafeEncoder.encode(joinKeyAndIndex(i)));
+            }
+
+            List<Object> objs = p.syncAndReturnAll();
+            for (int i = 0; i < objs.size(); i++) {
+                dels += BuilderFactory.LONG.build(objs.get(i));
+            }
+        }
+        return dels;
+    }
+}

--- a/src/main/java/com/aliyun/tair/leaderboard/LeaderBoard.java
+++ b/src/main/java/com/aliyun/tair/leaderboard/LeaderBoard.java
@@ -1,0 +1,423 @@
+package com.aliyun.tair.leaderboard;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.aliyun.tair.ModuleCommand;
+import com.aliyun.tair.leaderboard.params.RankParams;
+import com.aliyun.tair.util.JoinParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.BuilderFactory;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.Protocol.Command;
+import redis.clients.jedis.util.SafeEncoder;
+
+import static redis.clients.jedis.Protocol.toByteArray;
+
+public class LeaderBoard {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LeaderBoard.class);
+
+    private static final String CH = "CH";
+    private static final String WITHSCORES = "WITHSCORES";
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final boolean DEFAULT_REVERSE = false;
+    private static final boolean DEFAULT_USE_ZERO_INDEX = true;
+
+    private final String name;
+    private final byte[] nameBinary;
+    private final JedisPool jedisPool;
+    private final int pageSize;
+    private final boolean reverse;
+    private final boolean useZeroIndexForRank;
+
+    public LeaderBoard(String name, JedisPool jedisPool) {
+        this(name, jedisPool, DEFAULT_PAGE_SIZE);
+    }
+
+    public LeaderBoard(String name, JedisPool jedisPool, int pageSize) {
+        this(name, jedisPool, pageSize, DEFAULT_REVERSE);
+    }
+
+    public LeaderBoard(String name, JedisPool jedisPool, int pageSize, boolean reverse) {
+        this(name, jedisPool, pageSize, reverse, DEFAULT_USE_ZERO_INDEX);
+    }
+
+    public LeaderBoard(String name, JedisPool jedisPool, int pageSize, boolean reverse, boolean useZeroIndexForRank) {
+        this.name = name;
+        this.nameBinary = SafeEncoder.encode(name);
+        this.jedisPool = jedisPool;
+        this.pageSize = pageSize;
+        this.reverse = reverse;
+        this.useZeroIndexForRank = useZeroIndexForRank;
+    }
+
+    public static String joinScoresToString(final double... scores) {
+        StringBuilder mscore = new StringBuilder();
+        for (double score : scores) {
+            mscore.append(score);
+            mscore.append("#");
+        }
+        return mscore.substring(0, mscore.length() - 1);
+    }
+
+    /**
+     * Add a member to leaderboard.
+     *
+     * @param member the member
+     * @param scores the scores
+     * @return true: success set or update, false: element already exists and has the same score.
+     */
+    public Boolean addMember(final String member, final String scores) {
+        return addMember(SafeEncoder.encode(member), SafeEncoder.encode(scores));
+    }
+
+    public Boolean addMember(final String member, final double... scores) {
+        return addMember(SafeEncoder.encode(member), SafeEncoder.encode(joinScoresToString(scores)));
+    }
+
+    public Boolean addMember(final byte[] member, final double... scores) {
+        return addMember(member, SafeEncoder.encode(joinScoresToString(scores)));
+    }
+
+    public Boolean addMember(final byte[] member, final byte[] score) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(ModuleCommand.EXZADD, nameBinary, SafeEncoder.encode(CH), score, member);
+            return BuilderFactory.BOOLEAN.build(obj);
+        }
+    }
+
+    /**
+     * Add multi members to leaderboard.
+     * @param memberScores key : member, value: score
+     * @return list of insert status.
+     */
+    public List<Boolean> addMember(final Map<String, String> memberScores) {
+        List<Boolean> results = new ArrayList<>();
+        try (Jedis jedis = jedisPool.getResource()) {
+            Pipeline p = jedis.pipelined();
+            for (Map.Entry<String, String> entry : memberScores.entrySet()) {
+                p.sendCommand(ModuleCommand.EXZADD, nameBinary, SafeEncoder.encode(CH),
+                    SafeEncoder.encode(entry.getValue()), SafeEncoder.encode(entry.getKey()));
+            }
+
+            List<Object> objs = p.syncAndReturnAll();
+            for (Object obj : objs) {
+                results.add(BuilderFactory.BOOLEAN.build(obj));
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Change score for member.
+     *
+     * @param member the member
+     * @param increment the increment (negative value to decrement)
+     * @return the new score of member.
+     */
+    public String incrScoreFor(final String member, final String increment) {
+        return incrScoreFor(SafeEncoder.encode(member), increment);
+    }
+
+    public String incrScoreFor(final byte[] member, final String increment) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(ModuleCommand.EXZINCRBY, nameBinary, SafeEncoder.encode(increment),
+                member);
+            return BuilderFactory.STRING.build(obj);
+        }
+    }
+
+    /**
+     * Remove member from leaderboard.
+     *
+     * @param members the members
+     * @return The number of members removed from the leaderboard.
+     */
+    public Long removeMember(final String... members) {
+        return removeMember(SafeEncoder.encodeMany(members));
+    }
+
+    public Long removeMember(final byte[]... members) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(ModuleCommand.EXZREM, JoinParameters.joinParameters(nameBinary, members));
+            return BuilderFactory.LONG.build(obj);
+        }
+    }
+
+    /**
+     * Total members of the leaderboard.
+     *
+     * @return total members of the leaderboard, 0 if key does not exist.
+     */
+    public Long totalMembers() {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(ModuleCommand.EXZCARD, nameBinary);
+            return BuilderFactory.LONG.build(obj);
+        }
+    }
+
+    /**
+     * Total pages of the leaderboard.
+     *
+     * @return total pages of the leaderboard.
+     */
+    public Long totalPages() {
+        return (long)Math.ceil((double)totalMembers() / (double)pageSize);
+    }
+
+    /**
+     * The total of members in the current leaderboard in a score range.
+     *
+     * @param minScore Minimum score
+     * @param maxScore Maximum score
+     * @return Total of members in the current leaderboard in a score range.
+     */
+    public Long totalMembersInScoreRange(final double minScore, final double maxScore) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(ModuleCommand.EXZCOUNT, nameBinary,
+                toByteArray(minScore), toByteArray(maxScore));
+            return BuilderFactory.LONG.build(obj);
+        }
+    }
+
+    public Long totalMembersInScoreRange(final String minScore, final String maxScore) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(ModuleCommand.EXZCOUNT, nameBinary,
+                SafeEncoder.encode(minScore), SafeEncoder.encode(maxScore));
+            return BuilderFactory.LONG.build(obj);
+        }
+    }
+
+    /**
+     * Remove members from the current leaderboard in a given score range.
+     *
+     * @param minScore Minimum score
+     * @param maxScore Maximum score
+     * @return the number of members removed.
+     */
+    public Long removeMembersInScoreRange(final double minScore, final double maxScore) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(ModuleCommand.EXZREMRANGEBYSCORE, nameBinary,
+                toByteArray(minScore), toByteArray(maxScore));
+            return BuilderFactory.LONG.build(obj);
+        }
+    }
+
+    public Long removeMembersInScoreRange(final String minScore, final String maxScore) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(ModuleCommand.EXZREMRANGEBYSCORE, nameBinary,
+                SafeEncoder.encode(minScore), SafeEncoder.encode(maxScore));
+            return BuilderFactory.LONG.build(obj);
+        }
+    }
+
+
+    /**
+     * Retrieve the score for a member in the current leaderboard.
+     *
+     * @param member Member
+     * @return Member score.
+     */
+    public String scoreFor(final String member) {
+        return scoreFor(SafeEncoder.encode(member));
+    }
+
+    public String scoreFor(final byte[] member) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(ModuleCommand.EXZSCORE, nameBinary, member);
+            return BuilderFactory.STRING.build(obj);
+        }
+    }
+
+    /**
+     * Retrieve the rank for a member in the current leaderboard.
+     *
+     * @param member Member
+     * @return Rank for member in the current leaderboard.
+     */
+    public Long rankFor(final String member) {
+        return rankFor(SafeEncoder.encode(member), new RankParams());
+    }
+
+    public Long rankFor(final byte[] member) {
+        return rankFor(member, new RankParams());
+    }
+
+    public Long rankFor(final String member, final RankParams rankParams) {
+        return rankFor(SafeEncoder.encode(member), rankParams);
+    }
+
+    public Long rankFor(final byte[] member, final RankParams rankParams) {
+        Object obj;
+        Long rank;
+        try (Jedis jedis = jedisPool.getResource()) {
+            if (reverse) {
+                obj = jedis.sendCommand(ModuleCommand.EXZREVRANK, rankParams.getByteParams(nameBinary, member));
+            } else {
+                obj = jedis.sendCommand(ModuleCommand.EXZRANK, rankParams.getByteParams(nameBinary, member));
+            }
+        }
+        rank = BuilderFactory.LONG.build(obj);
+        if (rank != null && !useZeroIndexForRank) {
+            rank += 1;
+        }
+        return rank;
+    }
+
+    /**
+     * Retrieve score and rank for a member in the current leaderboard.
+     *
+     * @param member Member
+     * @return Score and rank for a member in the current leaderboard.
+     */
+    public LeaderData scoreAndRankFor(final String member) {
+        return scoreAndRankFor(SafeEncoder.encode(member));
+    }
+
+    public LeaderData scoreAndRankFor(final byte[] member) {
+        String score = scoreFor(member);
+        Long rank = rankFor(member);
+        return new LeaderData(new String(member), score, rank);
+    }
+
+    /**
+     * Get the leaderboard top number.
+     *
+     * @param number the number
+     * @return members from the leaderboard that fall within the given rank range.
+     */
+    public List<LeaderData> top(long number) {
+        Object obj;
+        List<LeaderData> leaderDataList = new ArrayList<>();
+
+        if (number < 1) {
+            number = 1;
+        }
+        long totalMembers = totalMembers();
+        long startRank = 0;
+        long endRank = number > totalMembers ? totalMembers-1 : number-1;
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            if (reverse) {
+                obj = jedis.sendCommand(ModuleCommand.EXZREVRANGE, nameBinary, toByteArray(startRank),
+                    toByteArray(endRank), SafeEncoder.encode(WITHSCORES));
+            } else {
+                obj = jedis.sendCommand(ModuleCommand.EXZRANGE, nameBinary, toByteArray(startRank),
+                    toByteArray(endRank), SafeEncoder.encode(WITHSCORES));
+            }
+            List<String> rangeRets = BuilderFactory.STRING_LIST.build(obj);
+            if (rangeRets != null) {
+                for (int i = 0; i < rangeRets.size(); i += 2) {
+                    String member = rangeRets.get(i);
+                    String score = rangeRets.get(i + 1);
+                    Long rank = rankFor(member);
+                    leaderDataList.add(new LeaderData(member, score, rank));
+                }
+            }
+        }
+        return leaderDataList;
+    }
+
+    /**
+     * Retrieve a page of leaders from the leaderboard.
+     *
+     * @param page the page
+     * @return a page of leaders from the leaderboard.
+     */
+    public List<LeaderData> leaders(long page) {
+        List<LeaderData> leaderDataList = new ArrayList<>();
+        Object obj;
+
+        if (page < 1) {
+            page = 1;
+        }
+
+        long totalPage = totalPages();
+        if (page > totalPage) {
+            page = totalPage;
+        }
+
+        long startOffset = (page - 1) * pageSize;
+        long endOffset = startOffset + pageSize - 1;
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            if (reverse) {
+                obj = jedis.sendCommand(ModuleCommand.EXZREVRANGE, nameBinary, toByteArray(startOffset),
+                    toByteArray(endOffset), SafeEncoder.encode(WITHSCORES));
+            } else {
+                obj = jedis.sendCommand(ModuleCommand.EXZRANGE, nameBinary, toByteArray(startOffset),
+                    toByteArray(endOffset), SafeEncoder.encode(WITHSCORES));
+            }
+            List<String> rangeRets = BuilderFactory.STRING_LIST.build(obj);
+            if (rangeRets != null) {
+                for (int i = 0; i < rangeRets.size(); i += 2) {
+                    String member = rangeRets.get(i);
+                    String score = rangeRets.get(i + 1);
+                    Long rank = rankFor(member);
+                    leaderDataList.add(new LeaderData(member, score, rank));
+                }
+            }
+        }
+        return leaderDataList;
+    }
+
+    /**
+     * Retrieves all leaders from the named leaderboard.
+     * @return the named leaderboard.
+     */
+    public List<LeaderData> allLeaders() {
+        List<LeaderData> leaderDataList = new ArrayList<>();
+        Object obj;
+        long startOffset = 0;
+        long endOffset = -1;
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            if (reverse) {
+                obj = jedis.sendCommand(ModuleCommand.EXZREVRANGE, nameBinary, toByteArray(startOffset),
+                    toByteArray(endOffset), SafeEncoder.encode(WITHSCORES));
+            } else {
+                obj = jedis.sendCommand(ModuleCommand.EXZRANGE, nameBinary, toByteArray(startOffset),
+                    toByteArray(endOffset), SafeEncoder.encode(WITHSCORES));
+            }
+            List<String> rangeRets = BuilderFactory.STRING_LIST.build(obj);
+            if (rangeRets != null) {
+                for (int i = 0; i < rangeRets.size(); i += 2) {
+                    String member = rangeRets.get(i);
+                    String score = rangeRets.get(i + 1);
+                    Long rank = rankFor(member);
+                    leaderDataList.add(new LeaderData(member, score, rank));
+                }
+            }
+        }
+        return leaderDataList;
+    }
+
+    /**
+     * Expire the current leaderboard in a set number of seconds.
+     *
+     * @param seconds the seconds
+     * @return Number of seconds after which the leaderboard will be expired.
+     */
+    public Long expireLeaderBoard(final long seconds) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(Command.EXPIRE, nameBinary, toByteArray(seconds));
+            return BuilderFactory.LONG.build(obj);
+        }
+    }
+
+    /**
+     * Delete the current leaderboard.
+     * @return success: 1, not found: 0
+     */
+    public Long delLeaderBoard() {
+        try (Jedis jedis = jedisPool.getResource()) {
+            Object obj = jedis.sendCommand(Command.DEL, nameBinary);
+            return BuilderFactory.LONG.build(obj);
+        }
+    }
+
+}

--- a/src/main/java/com/aliyun/tair/leaderboard/LeaderData.java
+++ b/src/main/java/com/aliyun/tair/leaderboard/LeaderData.java
@@ -1,0 +1,84 @@
+package com.aliyun.tair.leaderboard;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LeaderData implements Comparable<LeaderData> {
+	private String member;
+	private String score;
+	private Long rank;
+
+	/**
+	 * Store leader data
+	 *
+	 * @param member Name
+	 * @param score Score
+	 * @param rank Rank
+	 */
+	public LeaderData(String member, String score, Long rank) {
+		this.member = member;
+		this.score = score;
+		this.rank = rank;
+	}
+
+	public String getMember() {
+		return member;
+	}
+
+	public void setMember(String member) {
+		this.member = member;
+	}
+
+	public String getScore() {
+		return score;
+	}
+
+	public void setScore(String score) {
+		this.score = score;
+	}
+
+	public Long getRank() {
+		return rank;
+	}
+
+	public void setRank(Long rank) {
+		this.rank = rank;
+	}
+
+	List<Double> parseScoreFromStr(final String scores) {
+		String[] splits = scores.split("#");
+		List<Double> doubles = new ArrayList<>();
+		for (String s : splits) {
+			doubles.add(Double.parseDouble(s));
+		}
+		return doubles;
+	}
+
+	@Override
+	public int compareTo(LeaderData o) {
+		List<Double> local = parseScoreFromStr(getScore());
+		List<Double> compare = parseScoreFromStr(o.getScore());
+		for (int i = 0; i < local.size(); i++) {
+			Double a = local.get(i), b = compare.get(i);
+			if (a < b) {
+				return -1;
+			} else if (a > b) {
+				return 1;
+			}
+		}
+		return 0;
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder("{");
+		sb.append("\"member\":\"")
+			.append(member).append('\"');
+		sb.append(",\"score\":\"")
+			.append(score).append('\"');
+		sb.append(",\"rank\":")
+			.append(rank);
+		sb.append('}');
+		return sb.toString();
+	}
+}

--- a/src/main/java/com/aliyun/tair/leaderboard/params/RankParams.java
+++ b/src/main/java/com/aliyun/tair/leaderboard/params/RankParams.java
@@ -1,0 +1,41 @@
+package com.aliyun.tair.leaderboard.params;
+
+import java.util.ArrayList;
+
+import redis.clients.jedis.params.Params;
+import redis.clients.jedis.util.SafeEncoder;
+
+public class RankParams extends Params {
+    private static final String APPROXIMATE = "APPROXIMATE";
+
+    public RankParams() {}
+
+    public static RankParams RankParams() {
+        return new RankParams();
+    }
+
+    public RankParams approximate() {
+        addParam(APPROXIMATE);
+        return this;
+    }
+
+    private void addParamWithValue(ArrayList<byte[]> byteParams, String option) {
+        if (contains(option)) {
+            byteParams.add(SafeEncoder.encode(option));
+            byteParams.add(SafeEncoder.encode(String.valueOf((Object)getParam(option))));
+        }
+    }
+
+    public byte[][] getByteParams(byte[]... args) {
+        ArrayList<byte[]> byteParams = new ArrayList<byte[]>();
+        for (byte[] arg : args) {
+            byteParams.add(arg);
+        }
+
+        if (contains(APPROXIMATE)) {
+            byteParams.add(SafeEncoder.encode(APPROXIMATE));
+        }
+
+        return byteParams.toArray(new byte[byteParams.size()][]);
+    }
+}

--- a/src/test/java/com/aliyun/tair/tests/leaderboard/DistributedLeaderBoardTest.java
+++ b/src/test/java/com/aliyun/tair/tests/leaderboard/DistributedLeaderBoardTest.java
@@ -1,0 +1,140 @@
+package com.aliyun.tair.tests.leaderboard;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.aliyun.tair.leaderboard.DistributedLeaderBoard;
+import com.aliyun.tair.leaderboard.LeaderData;
+import com.aliyun.tair.tests.TestBase;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class DistributedLeaderBoardTest extends TestBase {
+    private static DistributedLeaderBoard dlb;
+
+    @BeforeClass
+    public static void beforeClass() {
+        dlb = new DistributedLeaderBoard("distributed_leaderboard", jedisPool);
+    }
+
+    @Before
+    public void before() {
+        // del first
+        dlb.delLeaderBoard();
+
+        for (int i = 0; i < 55; i++) {
+            dlb.addMember("member_" + i , i);
+        }
+    }
+
+    @Test
+    public void add_multi_member_test() {
+        Map<String, String> memberScores = new HashMap<String, String>() {{
+            put("tom", "10");
+            put("jonny", "20");
+            put("danny", "30");
+        }};
+        dlb.addMember(memberScores);
+        assertEquals("10", dlb.scoreFor("tom"));
+        assertEquals(58, (long)dlb.totalMembers());
+    }
+
+    @Test
+    public void change_score_for_test() {
+        dlb.incrScoreFor("member_0", "100");
+        assertEquals("100", dlb.scoreFor("member_0"));
+    }
+
+    @Test
+    public void remove_member_test() {
+        dlb.removeMember("member_0");
+        assertEquals(54, (long)dlb.totalMembers());
+    }
+
+    @Test
+    public void total_members() {
+        assertEquals(55, (long)dlb.totalMembers());
+    }
+
+    @Test
+    public void total_pages() {
+        assertEquals(6, (long)dlb.totalPages());
+    }
+
+    @Test
+    public void total_members_in_score_range_test() {
+        assertEquals(11, (long)dlb.totalMembersInScoreRange(10, 20));
+        assertEquals(55, (long)dlb.totalMembersInScoreRange(0, 100));
+    }
+
+    @Test
+    public void remove_members_in_score_range_test() {
+        assertEquals(11, (long)dlb.removeMembersInScoreRange(10, 20));
+        assertEquals(44, (long)dlb.removeMembersInScoreRange(0, 100));
+    }
+
+    @Test
+    public void score_for_test() {
+        assertEquals("0", dlb.scoreFor("member_0"));
+        dlb.removeMember("member_0");
+        assertNull(dlb.scoreFor("member_0"));
+    }
+
+    @Test
+    public void rank_for_test() {
+        for (int i = 0; i < 55; i++) {
+            assertEquals(i, (long)dlb.rankFor("member_" + i));
+        }
+    }
+
+    @Test
+    public void score_and_rank_for_test() {
+        LeaderData leaderData = dlb.scoreAndRankFor("member_0");
+        assertEquals(0, (long)leaderData.getRank());
+        assertEquals("0", leaderData.getScore());
+        assertEquals("member_0", leaderData.getMember());
+    }
+
+    @Test
+    public void top_i_test() {
+        List<LeaderData> tops = dlb.top(55);
+        assertEquals(55, tops.size());
+        for (int i = 0; i < tops.size(); i++) {
+            assertEquals(i + "", tops.get(i).getScore());
+        }
+    }
+
+    @Test
+    public void leaders_i_test() {
+        List<LeaderData> leaders = dlb.leaders(2);
+        assertEquals(10, leaders.size());
+        for (int i = 0; i < leaders.size(); i++) {
+            assertEquals(String.valueOf(i + 10), leaders.get(i).getScore());
+        }
+    }
+
+    @Test
+    public void expire_leaderboard_test() throws Exception {
+        dlb.expireLeaderBoard(1);
+        Thread.sleep(2000);
+        assertEquals(0, (long)dlb.delLeaderBoard());
+    }
+
+    @Test
+    public void rank_reverse_test() {
+        DistributedLeaderBoard idlb =
+            new DistributedLeaderBoard("rank_reverse_test", jedisPool, 10, 10, true);
+        for (int i = 0; i < 55; i++) {
+            idlb.addMember("member_" + i, i);
+        }
+
+        for (int i = 0; i < 55; i++) {
+            assertEquals(55 - i - 1, (long)idlb.rankFor("member_" + i));
+        }
+    }
+}

--- a/src/test/java/com/aliyun/tair/tests/leaderboard/LeaderBoardMultiScoreTest.java
+++ b/src/test/java/com/aliyun/tair/tests/leaderboard/LeaderBoardMultiScoreTest.java
@@ -1,0 +1,126 @@
+package com.aliyun.tair.tests.leaderboard;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import com.aliyun.tair.leaderboard.LeaderBoard;
+import com.aliyun.tair.leaderboard.LeaderData;
+import com.aliyun.tair.tests.TestBase;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class LeaderBoardMultiScoreTest extends TestBase {
+    private static LeaderBoard lb;
+    private static List<LeaderData> leaderDataList;
+
+    @BeforeClass
+    public static void beforeClass() {
+        lb = new LeaderBoard("leaderboard", jedisPool);
+        leaderDataList = new ArrayList<>();
+    }
+
+    @Before
+    public void before() {
+        // clean first
+        lb.delLeaderBoard();
+        leaderDataList.clear();
+
+        Random r = new Random();
+        for (int i = 0; i < 55; i++) {
+            double[] scores = new double[3];
+            scores[0] = r.nextDouble();
+            scores[1] = r.nextDouble();
+            scores[2] = r.nextDouble();
+
+            // add lb
+            lb.addMember("member_" + i, scores);
+
+            // add DataList
+            String scoreStr = LeaderBoard.joinScoresToString(scores);
+            LeaderData leaderData = new LeaderData("member_" + i,  scoreStr, 1L);
+            leaderDataList.add(leaderData);
+        }
+    }
+
+    @Test
+    public void multi_score_add_test() {
+        // get all leaders
+        List<LeaderData> top = lb.allLeaders();
+
+        // sort DataList
+        Collections.sort(leaderDataList);
+
+        for (int i = 0; i < top.size(); i++) {
+            assertEquals(top.get(i).getMember(), leaderDataList.get(i).getMember());
+        }
+    }
+
+    @Test
+    public void change_score_for_test() {
+        // diff dimension score will get error
+        try {
+            lb.incrScoreFor("member_0", "1#1#1#1");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("score is not a valid format"));
+        }
+
+        // change score
+        String newScore = "1#1#1";
+        assertTrue(lb.addMember("member_0", newScore));
+        assertEquals(54, (long)lb.rankFor("member_0"));
+    }
+
+    @Test
+    public void remove_member_test() {
+        lb.removeMember("member_0");
+        assertNull(lb.rankFor("member_0"));
+    }
+
+    @Test
+    public void total_members_in_score_range_test() {
+        // sort first
+        Collections.sort(leaderDataList);
+
+        String minScore = leaderDataList.get(10).getScore();
+        String maxScore = leaderDataList.get(20).getScore();
+        assertEquals(11, (long)lb.totalMembersInScoreRange(minScore, maxScore));
+        assertEquals(55, (long)lb.totalMembers());
+    }
+
+    @Test
+    public void remove_members_in_score_range_test() {
+        // sort first
+        Collections.sort(leaderDataList);
+
+        String minScore = leaderDataList.get(10).getScore();
+        String maxScore = leaderDataList.get(20).getScore();
+        assertEquals(11, (long)lb.removeMembersInScoreRange(minScore, maxScore));
+        assertEquals(44, (long)lb.totalMembers());
+    }
+
+    @Test
+    public void score_for_test() {
+        lb.scoreFor("member_0");
+        lb.removeMember("member_0");
+        assertNull(lb.scoreFor("member_0"));
+    }
+
+    @Test
+    public void rank_for_test() {
+        // sort first
+        Collections.sort(leaderDataList);
+
+        String firstMember = leaderDataList.get(0).getMember();
+
+        assertEquals(0, (long)lb.rankFor(firstMember));
+        lb.removeMember(firstMember);
+        assertNull(lb.rankFor(firstMember));
+    }
+}

--- a/src/test/java/com/aliyun/tair/tests/leaderboard/LeaderBoardTest.java
+++ b/src/test/java/com/aliyun/tair/tests/leaderboard/LeaderBoardTest.java
@@ -1,0 +1,128 @@
+package com.aliyun.tair.tests.leaderboard;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.aliyun.tair.leaderboard.LeaderBoard;
+import com.aliyun.tair.leaderboard.LeaderData;
+import com.aliyun.tair.tests.TestBase;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class LeaderBoardTest extends TestBase {
+    private static LeaderBoard lb;
+
+    @BeforeClass
+    public static void beforeClass() {
+        lb = new LeaderBoard("leaderboard", jedisPool);
+    }
+
+    @Before
+    public void before() {
+        // del first
+        lb.delLeaderBoard();
+
+        for (int i = 0; i < 55; i++) {
+            lb.addMember("member_" + i , i);
+        }
+    }
+
+    @Test
+    public void add_multi_member_test() {
+        Map<String, String> memberScores = new HashMap<String, String>() {{
+            put("tom", "10");
+            put("jonny", "20");
+            put("danny", "30");
+        }};
+        lb.addMember(memberScores);
+        assertEquals("10", lb.scoreFor("tom"));
+        assertEquals(58, (long)lb.totalMembers());
+    }
+
+    @Test
+    public void change_score_for_test() {
+        lb.incrScoreFor("member_0", "100");
+        assertEquals("100", lb.scoreFor("member_0"));
+    }
+
+    @Test
+    public void remove_member_test() {
+        lb.removeMember("member_0");
+        assertEquals(54, (long)lb.totalMembers());
+    }
+
+    @Test
+    public void total_members() {
+        assertEquals(55, (long)lb.totalMembers());
+    }
+
+    @Test
+    public void total_pages() {
+        assertEquals(6, (long)lb.totalPages());
+    }
+
+    @Test
+    public void total_members_in_score_range_test() {
+        assertEquals(11, (long)lb.totalMembersInScoreRange(10, 20));
+        assertEquals(55, (long)lb.totalMembersInScoreRange(0, 100));
+    }
+
+    @Test
+    public void remove_members_in_score_range_test() {
+        assertEquals(11, (long)lb.removeMembersInScoreRange(10, 20));
+        assertEquals(44, (long)lb.removeMembersInScoreRange(0, 100));
+    }
+
+    @Test
+    public void score_for_test() {
+        assertEquals("0", lb.scoreFor("member_0"));
+        lb.removeMember("member_0");
+        assertNull(lb.scoreFor("member_0"));
+    }
+
+    @Test
+    public void rank_for_test() {
+        assertEquals(54, (long)lb.rankFor("member_54"));
+        lb.removeMember("member_54");
+        assertNull(lb.scoreFor("member_54"));
+    }
+
+    @Test
+    public void score_and_rank_for_test() {
+        LeaderData leaderData = lb.scoreAndRankFor("member_0");
+        assertEquals(0, (long)leaderData.getRank());
+        assertEquals("0", leaderData.getScore());
+        assertEquals("member_0", leaderData.getMember());
+    }
+
+    @Test
+    public void top_i_test() {
+        List<LeaderData> tops = lb.top(22);
+        assertEquals(22, tops.size());
+        for (int i = 0; i < tops.size(); i++) {
+            assertEquals(i + "", tops.get(i).getScore());
+        }
+    }
+
+    @Test
+    public void leaders_i_test() {
+        List<LeaderData> leaders = lb.leaders(2);
+        assertEquals(10, leaders.size());
+        for (int i = 0; i < leaders.size(); i++) {
+            assertEquals(String.valueOf(i + 10), leaders.get(i).getScore());
+        }
+    }
+
+    @Test
+    public void expire_leaderboard_test() throws Exception {
+        lb.expireLeaderBoard(1);
+        Thread.sleep(2000);
+        assertEquals(0, (long)lb.delLeaderBoard());
+    }
+
+}


### PR DESCRIPTION
## Tair 排行榜方案

TairZset 是 Tair 团队自研的支持**多维排序**的数据结构（原始 Redis 的 Sorted Set 只能支持一维），此 PR 基于 TairZset 实现了单机和分布式排行榜方案。

- [x] 多维度排序
- [x] 分布式排行榜
- [x] 翻页和 Top 功能
- [ ] 估算排行榜
- [ ] 并列排行榜和竞争排行榜
- [ ] 实时榜、小时榜、周榜

```java
public class LeaderBoardExample {
    public static void main(String[] args) {
        JedisPool jedisPool = new JedisPool();

        LeaderBoard lb = new LeaderBoard("leaderboard", jedisPool);

        //             元素      积分 胜率 操作
        lb.addMember("member_1", 10,  7,  8);
        lb.addMember("member_2", 10,  7,  6);
        lb.addMember("member_3", 11,  7,  3);

        // 获取 member_1 的排名
        lb.rankFor("member_1"); // 1

        // 获取top2
        lb.top(2);
        // [{"member":"member_2","score":"10#7#6","rank":0}, {"member":"member_1","score":"10#7#8","rank":1}]

        // 获取排行榜第一页
        lb.leaders(1);
        // [{"member":"member_2","score":"10#7#6","rank":0}, {"member":"member_1","score":"10#7#8","rank":1},
        // {"member":"member_3","score":"11#7#3","rank":2}]
    }
}
```

其余的 API 还包括 `incrScoreFor`, `totalMembers`, `totalPages`, `totalMembersInScoreRange`, `expire`等。 


## 并列排行榜和竞争排行榜
### 1，并列排行榜
```java
| member     | score | rank |
-----------------------------
| member_1   | 50    | 1    |
| member_2   | 50    | 1    |
| member_3   | 30    | 2    |
| member_4   | 30    | 2    |
| member_5   | 10    | 3    |
```
并列排行榜也是用户很常见的需求，在 Stackoverflow 上有相关问题：[How to get same rank for same scores in Redis' ZRANK?](https://stackoverflow.com/questions/52152217/how-to-get-same-rank-for-same-scores-in-redis-zrank) RedisLabs 的人也回答了此问题，并且在 Redis 的 PR 列表中，14 年的时候，提交 GEO 功能的开发者 [mattsta](https://github.com/mattsta) 也贡献过相关的 PR：[https://github.com/redis/redis/pull/2011](https://github.com/redis/redis/pull/2011)，但是最后没有被合并。
> ZRANK key member [UNIQUE]
 如果带了 UNIQUE ，则排名时候按照并列处理

### 2，竞争排行榜
```java
| member     | score | rank |
-----------------------------
| member_1   | 50    | 1    |
| member_2   | 50    | 1    |
| member_3   | 30    | 3    |
| member_4   | 30    | 3    |
| member_5   | 10    | 5    |
```


可以在 TairZset 提供获取排名时候支持 UNIQUE 和 COMPETITION 的选项，获取排名的时候按照并列或者竞争排行榜来返回排名。
​

## 月榜周榜日榜小时榜及实时榜
利用 TairZset 多级索引能力可以轻松实现不同时间范围的排行榜。
​

### 方案一：自上而下
所有数据 all in one key, 假设用户的最大需求是月榜，那么这个 key 就从月来索引：
```powershell
// key: julyZset
// 7#2#6#16#22#100: 7月第2周6号16点22分，更新值为100
// 7#2#6#16#22_user1: 此时间点更新的user，前缀需要具体时间
127.0.0.1:6379> exzincrby julyZset 7#2#6#16#22#100 7#2#6#16#22_user1
"7#2#6#16#22#100"
127.0.0.1:6379> exzincrby julyZset 7#2#6#16#22#50 7#2#6#16#22_user2
"7#2#6#16#22#50"
127.0.0.1:6379> exzincrby julyZset 7#2#6#16#23#70 7#2#6#16#23_user1
"7#2#6#16#23#70"
127.0.0.1:6379> exzincrby julyZset 7#2#6#16#23#80 7#2#6#16#23_user1
"14#4#12#32#46#150"
127.0.0.1:6379>

// 查询小时级别实时榜，从当前时间往前推算一个小时 16:23 ~ 15:23，如果访问非常频繁，可以缓存下来
// 下一分钟访问
127.0.0.1:6379> exzrevrangebyscore julyZset 7#2#6#16#23#0 7#2#6#15#23#0
1) "7#2#6#16#22_user1"
2) "7#2#6#16#22_user2"
127.0.0.1:6379>

// 查询固定一个小时，比如 16:00 ~ 17:00
127.0.0.1:6379> exzrevrangebyscore julyZset 7#2#6#17#0#0 7#2#6#16#0#0
1) "7#2#6#16#22_user1"
2) "7#2#6#16#22_user2"
127.0.0.1:6379>

// 再插入一些7月5号的数据，然后查询7月5号的日榜
127.0.0.1:6379> exzincrby julyZset 7#2#5#10#23#70 7#2#5#10#23_user1
"7#2#5#10#23#70"
127.0.0.1:6379> exzrevrangebyscore julyZset 7#2#6#0#0#0 7#2#5#0#0#0
1) "7#2#5#10#23_user1"
127.0.0.1:6379>

// 查询7月第2周榜
127.0.0.1:6379> exzrevrangebyscore julyZset 7#3#0#0#0#0 7#2#0#0#0#0
1) "7#2#6#16#22_user1"
2) "7#2#6#16#22_user2"
3) "7#2#5#10#23_user1"
127.0.0.1:6379>
```


### 方案二：自下而上
所有的数据放在一个 key 底下，小型业务可以，但是中大型业务可能不行，因此方法二从小的榜单开始构建，假设业务最小的粒度是分钟级别。
```powershell
// 每个key都是分钟级别的
127.0.0.1:6379> exzincrby 7#2#6#16#22 100 user1
100
127.0.0.1:6379> exzincrby 7#2#6#16#22 50 user2
50
127.0.0.1:6379> exzincrby 7#2#6#16#23 10 user1
10
127.0.0.1:6379> exzincrby 7#2#6#16#23 70 user2
70
127.0.0.1:6379>

// 如果需要某分钟开始之前一小时的数据，需要找到所有的相关key，将其exzunionstore
// exzunionstore TairZset 暂时不支持
exzunionstore 7#2#6#16#23#hour 60 7#2#6#16#23 7#2#6#16#22 ... 7#2#6#15#23 

// 如果某个固定小时，比如16：00
exzunionstore 7#2#6#16 60 7#2#6#16#59 ... 7#2#6#16#0

// 如果要获取天榜
exzunionstore 7#2#6 24 7#2#6#23 ... 7#2#6#0

// 如果获取周榜
exzunionstore 7#2 7 7#2#11 ... 7#2#5
```





