### PR TITLE
Deprecate exhscanunorder command

### DIFF
--- a/src/main/java/com/aliyun/tair/ModuleCommand.java
+++ b/src/main/java/com/aliyun/tair/ModuleCommand.java
@@ -47,6 +47,7 @@ public enum ModuleCommand implements ProtocolCommand {
     EXHGETALL("EXHGETALL"),
     EXHMGETWITHVER("EXHMGETWITHVER"),
     EXHSCAN("EXHSCAN"),
+    @Deprecated
     EXHSCANUNORDER("EXHSCANUNORDER"),
 
     // CAS & CAD

--- a/src/main/java/com/aliyun/tair/tairhash/TairHash.java
+++ b/src/main/java/com/aliyun/tair/tairhash/TairHash.java
@@ -902,11 +902,14 @@ public class TairHash {
      * @param key the key
      * @param cursor the cursor
      * @return ScanResult
+     * @deprecated This command is no longer supported on v4 persistent memory instances. Use exhscan instead.
      */
+    @Deprecated
     public ScanResult<Entry<String, String>> exhscanunorder(final String key, final String cursor) {
         return exhscanunorder(key, cursor, new ScanParams());
     }
 
+    @Deprecated
     public ScanResult<Entry<byte[], byte[]>> exhscanunorder(final byte[] key, final byte[] cursor) {
         return exhscanunorder(key, cursor, new ScanParams());
     }
@@ -917,7 +920,9 @@ public class TairHash {
      * @param cursor
      * @param params
      * @return
+     * @deprecated This command is no longer supported on v4 persistent memory instances. Use exhscan instead.
      */
+    @Deprecated
     public ScanResult<Entry<String, String>> exhscanunorder(final String key, final String cursor,
         final ScanParams params) {
         final List<byte[]> args = new ArrayList<byte[]>();
@@ -934,6 +939,7 @@ public class TairHash {
         }
     }
 
+    @Deprecated
     public ScanResult<Entry<byte[], byte[]>> exhscanunorder(final byte[] key, final byte[] cursor,
         final ScanParams params) {
         final List<byte[]> args = new ArrayList<byte[]>();

--- a/src/main/java/com/aliyun/tair/tairhash/TairHashCluster.java
+++ b/src/main/java/com/aliyun/tair/tairhash/TairHashCluster.java
@@ -428,14 +428,26 @@ public class TairHashCluster {
         return HashBuilderFactory.EXHSCAN_RESULT_BYTE.build(obj);
     }
 
+    /**
+     * @deprecated This command is no longer supported on v4 persistent memory instances. Use exhscan instead.
+     */
+    @Deprecated
     public ScanResult<Entry<String, String>> exhscanunorder(final String key, final String cursor) {
         return exhscanunorder(key, cursor, new ScanParams());
     }
 
+    /**
+     * @deprecated This command is no longer supported on v4 persistent memory instances. Use exhscan instead.
+     */
+    @Deprecated
     public ScanResult<Entry<byte[], byte[]>> exhscanunorder(final byte[] key, final byte[] cursor) {
         return exhscanunorder(key, cursor, new ScanParams());
     }
 
+    /**
+     * @deprecated This command is no longer supported on v4 persistent memory instances. Use exhscan instead.
+     */
+    @Deprecated
     public ScanResult<Entry<String, String>> exhscanunorder(final String key, final String cursor,
         final ScanParams params) {
         final List<byte[]> args = new ArrayList<byte[]>();
@@ -448,6 +460,10 @@ public class TairHashCluster {
         return HashBuilderFactory.EXHSCAN_RESULT_STRING.build(obj);
     }
 
+    /**
+     * @deprecated This command is no longer supported on v4 persistent memory instances. Use exhscan instead.
+     */
+    @Deprecated
     public ScanResult<Entry<byte[], byte[]>> exhscanunorder(final byte[] key, final byte[] cursor,
         final ScanParams params) {
         final List<byte[]> args = new ArrayList<byte[]>();

--- a/src/main/java/com/aliyun/tair/tairhash/TairHashPipeline.java
+++ b/src/main/java/com/aliyun/tair/tairhash/TairHashPipeline.java
@@ -447,14 +447,26 @@ public class TairHashPipeline extends Pipeline {
             HashBuilderFactory.EXHSCAN_RESULT_BYTE));
     }
 
+    /**
+     * @deprecated This command is no longer supported on v4 persistent memory instances. Use exhscan instead.
+     */
+    @Deprecated
     public Response<ScanResult<Entry<String, String>>> exhscanunorder(final String key, final String cursor) {
         return exhscanunorder(key, cursor, new ScanParams());
     }
 
+    /**
+     * @deprecated This command is no longer supported on v4 persistent memory instances. Use exhscan instead.
+     */
+    @Deprecated
     public Response<ScanResult<Entry<byte[], byte[]>>> exhscanunorder(final byte[] key, final byte[] cursor) {
         return exhscanunorder(key, cursor, new ScanParams());
     }
 
+    /**
+     * @deprecated This command is no longer supported on v4 persistent memory instances. Use exhscan instead.
+     */
+    @Deprecated
     public Response<ScanResult<Entry<String, String>>> exhscanunorder(final String key, final String cursor,
         final ScanParams params) {
         final List<byte[]> args = new ArrayList<byte[]>();
@@ -466,6 +478,10 @@ public class TairHashPipeline extends Pipeline {
             HashBuilderFactory.EXHSCAN_RESULT_STRING));
     }
 
+    /**
+     * @deprecated This command is no longer supported on v4 persistent memory instances. Use exhscan instead.
+     */
+    @Deprecated
     public Response<ScanResult<Entry<byte[], byte[]>>> exhscanunorder(final byte[] key, final byte[] cursor,
         final ScanParams params) {
         final List<byte[]> args = new ArrayList<byte[]>();


### PR DESCRIPTION
## Summary

Mark `exhscanunorder` command as `@Deprecated` across all SDK classes.

This command is no longer supported on v4 persistent memory instances. Users should migrate to `exhscan` instead.

## Changes

- Added `@Deprecated` annotation to `EXHSCANUNORDER` enum value in `ModuleCommand.java`
- Added `@Deprecated` annotation with javadoc `@deprecated` tag to all 4 `exhscanunorder` methods in `TairHash.java`
- Added `@Deprecated` annotation with javadoc `@deprecated` tag to all 4 `exhscanunorder` methods in `TairHashCluster.java`
- Added `@Deprecated` annotation with javadoc `@deprecated` tag to all 4 `exhscanunorder` methods in `TairHashPipeline.java`

No code was removed — only deprecation markers were added.